### PR TITLE
Don't cd to ~/.i2pb/i2p-browser/Browser

### DIFF
--- a/usr/bin/i2pbrowser
+++ b/usr/bin/i2pbrowser
@@ -9,7 +9,7 @@ export IDENTIFIER="i2pbrowser"
 
 ICON="/usr/share/icons/anon-icon-pack/tbupdate.ico"
 
-if [ ! -d "$HOME/.i2pb/i2p-browser" ]; then
+if [ ! -d "$HOME/.i2pb/i2p-browser/Browser" ]; then
     update-i2pbrowser
     exit $?
 fi
@@ -28,8 +28,6 @@ if [ ! -L "$HOME/.i2pb/i2p-browser/Browser/TorBrowser/Data/Browser/profile.i2p" 
 fi
 
 cp -f /usr/share/tb-profile-i2p/start-i2p-browser "$HOME/.i2pb/i2p-browser/Browser/start-i2p-browser"
-
-cd "$HOME/.i2pb/i2p-browser/Browser/" || exit 1
 
 TOR_HIDE_UPDATE_CHECK_UI=1 \
     TOR_NO_DISPLAY_NETWORK_SETTINGS=1 \


### PR DESCRIPTION
This pull request removes the useless cd and useless exit code. The check for the existence of the i2p Browser at the top has been modified to check for that folder instead. That check is still required because without it, the profile will be constructed from non-existent components. I have tested this on my machine and it appears to work with a freshly run update-i2pbrowser.