### PR TITLE
Update SecBrowser landing page

### DIFF
--- a/usr/share/secbrowser/secbrowser.html
+++ b/usr/share/secbrowser/secbrowser.html
@@ -1,23 +1,87 @@
 <!DOCTYPE html>
 <html>
-    <title>SecBrowser &trade;</title>
+
+<a href="https://www.whonix.org/wiki/Donate" class="donation_button">Donate!</a>
+
+<title>SecBrowser &trade;</title>
 <body>
 <style>
-    body {background-color: lightblue; font-family: monospace; margin-left: auto; margin-right: auto; width: 80%; font-size: 14px;}
-    h1 {color: greenviolet; border: 10px solid seagreen; text-align: center; background-color: gold; margin-left: auto; margin-right: auto; width: 50%; font-size: 30px;}
-    h2 {color: darkviolet; border: 10px dotted darksalmon; text-align: center; background-color: gold; margin-left: auto; margin-right: auto; width: 50%; font-size: 24px;}
-    p {color: indigo; border: 3px dotted seagreen; margin-left: auto; margin-right: auto; width: 80%;}
+    body {background-color: midnightblue; font-family: monospace; margin-left: auto; margin-right: auto; width: 80%; font-size: 14px;}
+    h1 {color: white; text-align: center; margin-left: auto; margin-right: auto; width: 90%; font-size: 60px;}
+    h2 {color: white; text-align: center; margin-left: auto; margin-right: auto; width: 95%; font-size: 20px;}
+    p {color: white; margin-left: auto; margin-right: auto; width: 80%; font-size: 15px;}
+    p1 {color: white; margin-left: auto; margin-right: auto; width: 80%; font-size: 10px;}
+    p2 {color: white; margin-left: auto; margin-right: auto; width: 80%; font-size: 10px;}
 </style>
-<h1>SecBrowser &trade;</h1>
+<h1>Sec<i>Browser</i> &trade;</h1>
+<h2>A Security Hardened, non-anonymous browser</h2>
 
-<h2>A security hardened, non-anonymous browser.</h2>
+<br></br>
 
-<p>SecBrowser &trade; is a security focused browser that provides better protection from exploits, thereby reducing the risk of a virus infection. Enhanced usability is achieved with a built-in security slider that can be used to easily disable web site features that increase attack surface such as JavaScript. Since many of the features that are commonly exploited in browsers are disabled by default, SecBrowser &trade; attack surface is greatly reduced. In the default configuration, SecBrowser &trade; offers better security than Firefox, Google Chrome or Microsoft Edge without any customizations necessary. <a href=https://2019.www.torproject.org/projects/torbrowser/design>[1]</a> It also has better protections from <a href=https://www.whonix.org/wiki/Data_Collection_Techniques>online tracking</a>, <a href=http://www.whonix.org/wiki/Data_Collection_Techniques#Fingerprinting_of_Browser_.28HTTP.29_Header>browser fingerprinting</a> and reduces users linkability across websites.</p>
+<p>SecBrowser &trade; is a security focused browser that provides  protection from exploits that are commonly used to compromise browsers, thereby reducing the risk of a malware infection. Enhanced usability is achieved with a built-in security slider that easily disables JavaScript and other web site features that increase attack. Moreover SecBrowser protects from both <a href="https://www.whonix.org/wiki/Data_Collection_Techniques" style="color: aqua">online tracking</a> and <a href="http://www.whonix.org/wiki/Data_Collection_Techniques#Browser_Fingerprinting" style="color: aqua">browser fingerprinting</a> right out of the box while also reducing users linkability across websites.</p>
+<br></br>
 
-<p>SecBrowser &trade; is a derivative of Tor&reg; Browser Bundle. This means unlike Tor Browser, SecBrowser &trade; does <u>not</u> route traffic over the Tor&reg; network, which in common parlance is referred to as "clearnet" traffic. Even without the aid of the Tor&reg; network, SecBrowser &trade; still benefits from the numerous <a href=https://gitweb.torproject.org/tor-browser.git>patches</a> that Tor&reg; developers merged into the code base. Even with developer skills, these enhancements would be arduous and time consuming to duplicate in other browsers, with the outcome unlikely to match SecBrowser &trade; many security benefits. While users can install browser extensions to mitigate specific attack vectors. Its unlikely to compare to SecBrowser &trade; which leverages the experience and know how of the Tor Project devs and the battle tested Tor Browser.
+<br></br>
+    <table>
+      <table align="center" style="margin: 0px auto;" cellspacing="15">
+        <tr>
+          <th><a tabindex="1" href="https://forums.whonix.org/t/todo-research-and-document-how-to-use-tor-browser-for-security-not-anonymity-how-to-use-tbb-using-clearnet/3822" target="_blank" rel="noreferrer"><font size="5" color="white">Development</font></a></th>
+          <th><a tabindex="2" href="https://www.whonix.org/wiki/Support" target="_blank" rel="noreferrer"><font size="5" color="white">Support</font></a></th>
+          <th><a tabindex="3" href="https://www.whonix.org/wiki/Contribute" target="_blank" rel="noreferrer"><font size="5" color="white">Contribute</font></a></th>
+          <th><a tabindex="4" href="https://forums.whonix.org/t/hardened-debian-security-focused-linux-distribution-based-on-debian-in-development-feedback-wanted/5943" target="_blank" rel="noreferrer"><font size="5" color="yellow"><i>Sec</i><b>OS</b> &trade;</font><font size="3" color="yellow"> Comming Soon!</font></a></th>
+          </tr>
+      </table>
+<br></br>
 
-<p>Improvements to this SecBrowser &trade; local welcome page <a href=https://github.com/Whonix/tb-starter/blob/master/usr/share/secbrowser/secbrowser.html>are welcome</a>.</p>
+<p1>* SecBrowser &trade; is a derivative of the battel-tested Tor&reg; Browser that does <u>not</u> route traffic over the Tor&reg; network.</p1>
 
-<p>SecBrowser &trade; is produced independently from the Tor&reg; anonymity software and carries no guarantee from <a href=https://www.torproject.org>The Tor&reg; Project</a> about quality, suitability or anything else.</p>
+<p2>* SecBrowser &trade; is produced independently from Tor&reg; anonymity software and carries no guarantee from <a href="https://www.torproject.org" style="color: aqua">The Tor&reg; Project</a> about quality, suitability or anything else.</p2>
 </body>
 </html>
+
+<style type="text/css">
+.donation_button {
+        -moz-box-shadow:inset 0px 0px 0px 0px #fce2c1;
+        -webkit-box-shadow:inset 0px 0px 0px 0px #fce2c1;
+        box-shadow:inset 0px 0px 0px 0px #fce2c1;
+        background:-webkit-gradient( linear, left top, left bottom, color-stop(0.05, #ffc477), color-stop(1, #ff8c00) );
+        background:-moz-linear-gradient( center top, #ffc477 5%, #ff8c00 100% );
+        filter:progid:.gradient(startColorstr='#ffc477', endColorstr='#ff8c00');
+        background-color:#ffc477;
+        -webkit-border-top-left-radius:12px;
+        -moz-border-radius-topleft:12px;
+        border-top-left-radius:12px;
+        -webkit-border-top-right-radius:12px;
+        -moz-border-radius-topright:12px;
+        border-top-right-radius:12px;
+        -webkit-border-bottom-right-radius:12px;
+        -moz-border-radius-bottomright:12px;
+        border-bottom-right-radius:12px;
+        -webkit-border-bottom-left-radius:12px;
+        -moz-border-radius-bottomleft:12px;
+        border-bottom-left-radius:12px;
+text-indent:0px;
+        border:3px solid #eeb44f;
+        display:inline-block;
+        color:#ffffff;                  
+        font-family:Arial;
+        font-size:18px;
+        font-weight:normal;
+        font-style:normal;
+height:30px;
+        line-height:30px;
+width:78px;
+        text-decoration:none;
+        text-align:center;
+        text-shadow:0px -1px 0px #cc9f52;
+}.donation_button:hover {
+        background:-webkit-gradient( linear, left top, left bottom, color-stop(0.05, #ff8c00), color-stop(1, #ffc477) );
+        background:-moz-linear-gradient( center top, #ff8c00 5%, #ffc477 100% );
+        filter:progid: .gradient(startColorstr='#ff8c00', endColorstr='#ffc477');
+        background-color:#ff8c00;
+}.donation_button:active {
+        position:relative;
+        top:1px;
+}</style>
+
+


### PR DESCRIPTION
For the time being  paragraph `<p>` _might_ be useful since SecBrowser is not well know. However, once SecBrowser gains more traction `<p>` should be remove:

* `<h2>` Already states SecBrowser is  "A Security Hardened, non-anonymous browser" 
* `<p>` Makes the UI look to busy. Have not found any popular browsers with this much txt on the Welcome page. 
* Even Whonix -- a complete OS -- does not have this much txt on the landing page.
* Maybe a local `info` file:///home/user/secbrowser/info can be linked from the Welcome page. Content would be basic info (no configuration options). 
