### PR TITLE
Update link to home page.

### DIFF
--- a/usr/share/secbrowser/secbrowser.html
+++ b/usr/share/secbrowser/secbrowser.html
@@ -25,7 +25,7 @@
     <table>
       <table align="center" style="margin: 0px auto;" cellspacing="15">
         <tr>
-          <th><a tabindex="1" href="https://www.whonix.org/wiki/SecBrowser" target="_blank" rel="noreferrer"><font size="5" color="white">Homepage</font></a></th>
+          <th><a tabindex="1" href="https://www.whonix.org/wiki/SecBrowser_in_Debian" target="_blank" rel="noreferrer"><font size="5" color="white">Homepage</font></a></th>
           <th><a tabindex="1" href="https://forums.whonix.org/t/secbrowser-a-security-hardened-non-anonymous-browser/3822" target="_blank" rel="noreferrer"><font size="5" color="white">Development</font></a></th>
           <th><a tabindex="2" href="https://www.whonix.org/wiki/Support" target="_blank" rel="noreferrer"><font size="5" color="white">Support</font></a></th>
           <th><a tabindex="3" href="https://www.whonix.org/wiki/Contribute" target="_blank" rel="noreferrer"><font size="5" color="white">Contribute</font></a></th>


### PR DESCRIPTION
https://www.whonix.org/wiki/SecBrowser_in_Debian has a notice for Qubes users to navigate to the Qubes SecBrowser wiki page. So links to both pages are not necessary in `secbrowser.html`