### PR TITLE
Add support for Mullvad Browser

### DIFF
--- a/usr/bin/mullvadbrowser
+++ b/usr/bin/mullvadbrowser
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+## Copyright (C) 2018 - 2023 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+## See the file COPYING for copying conditions.
+
+export SCRIPTNAME="$(basename "$BASH_SOURCE")"
+
+export IDENTIFIER="mullvadbrowser"
+
+[ -n "$ICON" ] || export ICON="/usr/share/icons/icon-pack-dist/tbupdate.ico"
+[ -n "$tb_install_folder_dot" ] || export tb_install_folder_dot=".mullvadbrowser"
+[ -n "$tb_title" ] || export tb_title="Mullvad Browser"
+[ -n "$tb_wiki" ] || export tb_wiki="Mullvad_Browser"
+[ -n "$tb_browser_name" ] || export tb_browser_name="mullvad-browser"
+[ -n "$tb_browser_runner" ] || export tb_browser_runner="start-mullvad-browser"
+[ -n "$tb_settings_folder" ] || export tb_settings_folder="mullvadbrowser.d"
+
+torbrowser "$@"


### PR DESCRIPTION
Complementary to https://github.com/Kicksecure/tb-updater/issues/25 and https://github.com/Kicksecure/tb-updater/pull/26

This already appears to work, but here are some notes:

- Some variables do not appear to be used so they are not set, such as `$tb_bin` and `$tb_install_folder`
- The way the updater is launched needs to be changed. Also broken for i2pbrowser as of https://github.com/Kicksecure/tb-updater/commit/ac21f887493e9f6645af360108c69a62f379e68d. A simple variable like `$tb_updater_bin` would probably do.  https://github.com/Kicksecure/tb-starter/blob/6d201a06cef37d841ccb51bb8e5569466d67b2fb/usr/bin/torbrowser#L525-L530
- Does it make sense to check if variables are set with `[ -n` in `/usr/bin/mullvadbrowser`, as that is not the case with updater. For now I kept it this way for consistency with i2pbrowser
- `tb_custom_user_js_file` and `tb_copy_from_root_to_user_maybe` might need some looking into